### PR TITLE
small script directory fix

### DIFF
--- a/src/prompts/user/install.sh
+++ b/src/prompts/user/install.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # It will add imports to ~/.claude/CLAUDE.md that reference this repo's patterns
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 CLAUDE_DIR="$HOME/.claude"
 CLAUDE_FILE="$CLAUDE_DIR/CLAUDE.md"
 


### PR DESCRIPTION
Please ignore if this is incorrect, but I think this will fix an issue I had when I ran the script where there were two `src`s in the path.

i.e. it produced the following (notice the two `src`s):
```
# Socratic Shell Collaboration Patterns
@/home/reed/development/socratic-shell/src/src/prompts/user/main.md
``